### PR TITLE
Add code to generate signature from Method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExprTools"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
-authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.1.0"
+authors = ["Invenia Technical Computing"]
+version = "0.1.1"
 
 [compat]
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Alternatively see the [MacroTools](https://github.com/MikeInnes/MacroTools.jl) p
 
 Currently, this package provides the `splitdef`, `signature` and `combinedef` functions which are useful for inspecting and manipulating function definition expressions.
  - `splitdef` works on a function definition expression and returns a `Dict` of its parts.
+ - `combinedef` takes `Dict` from `splitdef` and builds it into an expression.
  - `signature` works on a `Method` returning a similar `Dict` that holds the parts of the expressions that would form its signature.
- - `combinedef` takes such `Dict` and builds it back into an expression
+
 
 e.g.
 ```julia

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Alternatively see the [MacroTools](https://github.com/MikeInnes/MacroTools.jl) p
 
 Currently, this package provides the `splitdef`, `signature` and `combinedef` functions which are useful for inspecting and manipulating function definition expressions.
  - `splitdef` works on a function definition expression and returns a `Dict` of its parts.
- - `combinedef` takes `Dict` from `splitdef` and builds it into an expression.
+ - `combinedef` takes a `Dict` from `splitdef` and builds it into an expression.
  - `signature` works on a `Method` returning a similar `Dict` that holds the parts of the expressions that would form its signature.
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ This package aims to provide light-weight performant tooling without requiring a
 
 Alternatively see the [MacroTools](https://github.com/MikeInnes/MacroTools.jl) package for a more powerful set of tools.
 
-Currently, this package provides the `splitdef` and `combinedef` functions which are useful for inspecting and manipulating function definition expressions.
+Currently, this package provides the `splitdef`, `signature` and `combinedef` functions which are useful for inspecting and manipulating function definition expressions.
+ - `splitdef` works on a function definition expression and returns a `Dict` of its parts.
+ - `signature` works on a `Method` returning a similar `Dict` that holds the parts of the expressions that would form its signature.
+ - `combinedef` takes such `Dict` and builds it back into an expression
 
 e.g.
 ```julia
@@ -40,6 +43,18 @@ julia> def[:head] = :(=);
 
 julia> def[:body] = :(x * y);
 
-julia> combinedef(def)
+julia> g_expr = combinedef(def)
 :((g(x::T, y::T) where T) = x * y)
+
+julia> eval(g_expr)
+g (generic function with 1 method)
+
+julia> g_method = first(methods(g))
+g(x::T, y::T) where T in Main
+
+julia> signature(g_method)
+Dict{Symbol,Any} with 3 entries:
+  :name        => :g
+  :args        => Expr[:(x::T), :(y::T)]
+  :whereparams => Any[:T]
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,4 +10,5 @@ CurrentModule = ExprTools
 ```@docs
 splitdef
 combinedef
+signature
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,16 @@ This package aims to provide light-weight performant tooling without requiring a
 
 Alternatively see the [MacroTools](https://github.com/MikeInnes/MacroTools.jl) package for more powerful set of tools.
 
-Currently, this package provides the `splitdef` and `combinedef` functions which are useful for inspecting and manipulating function definition expressions.
+
+ExprTools provides tooling for working with Julia expressions during [metaprogramming](https://docs.julialang.org/en/v1/manual/metaprogramming/).
+This package aims to provide light-weight performant tooling without requiring additional package dependencies.
+
+Alternatively see the [MacroTools](https://github.com/MikeInnes/MacroTools.jl) package for more powerful set of tools.
+
+Currently, this package provides the `splitdef`, `signature` and `combinedef` functions which are useful for inspecting and manipulating function definition expressions.
+ - [`splitdef`](@ref) works on a function definition expression and returns a `Dict` of its parts.
+ - [`signature`](@ref) works on a `Method` returning a similar `Dict` that holds the parts of the expressions that would form its signature.
+ - [`combinedef`](@ref) takes such `Dict` and builds it back into an expression
 
 e.g.
 ```jldoctest
@@ -35,6 +44,18 @@ julia> def[:head] = :(=);
 
 julia> def[:body] = :(x * y);
 
-julia> combinedef(def)
+julia> g_expr = combinedef(def)
 :((g(x::T, y::T) where T) = x * y)
+
+julia> eval(g_expr)
+g (generic function with 1 method)
+
+julia> g_method = first(methods(g))
+g(x::T, y::T) where T in Main
+
+julia> signature(g_method)
+Dict{Symbol,Any} with 3 entries:
+  :name        => :g
+  :args        => Expr[:(x::T), :(y::T)]
+  :whereparams => Any[:T]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,8 +13,8 @@ Alternatively see the [MacroTools](https://github.com/MikeInnes/MacroTools.jl) p
 
 Currently, this package provides the `splitdef`, `signature` and `combinedef` functions which are useful for inspecting and manipulating function definition expressions.
  - [`splitdef`](@ref) works on a function definition expression and returns a `Dict` of its parts.
+ - [`combinedef`](@ref) takes `Dict` from `splitdef` and builds it into an expression.
  - [`signature`](@ref) works on a `Method` returning a similar `Dict` that holds the parts of the expressions that would form its signature.
- - [`combinedef`](@ref) takes such `Dict` and builds it back into an expression
 
 e.g.
 ```jldoctest

--- a/src/ExprTools.jl
+++ b/src/ExprTools.jl
@@ -4,5 +4,5 @@ export signature, splitdef, combinedef
 
 include("function.jl")
 include("method.jl")
-
+include("type_utils.jl")
 end

--- a/src/ExprTools.jl
+++ b/src/ExprTools.jl
@@ -1,7 +1,8 @@
 module ExprTools
 
-export splitdef, combinedef
+export signature, splitdef, combinedef
 
 include("function.jl")
+include("method.jl")
 
 end

--- a/src/function.jl
+++ b/src/function.jl
@@ -137,9 +137,13 @@ end
 Create a function definition expression from various components. Typically used to construct
 a function using the result of [`splitdef`](@ref).
 
+If `def[:head]` is not provided it will default to `:function`.
+
 For more details see the documentation on [`splitdef`](@ref).
 """
 function combinedef(def::Dict{Symbol,Any})
+    head = get(def, :head, :function)
+
     # Determine the name of the function including parameterization
     name = if haskey(def, :params)
         Expr(:curly, def[:name], def[:params]...)
@@ -166,7 +170,7 @@ function combinedef(def::Dict{Symbol,Any})
     # Create a partial function signature including the name and arguments
     sig = if name !== nothing
         :($name($(args...)))  # Equivalent to `Expr(:call, name, args...)` but faster
-    elseif def[:head] === :(->) && length(args) == 1 && !haskey(def, :kwargs)
+    elseif head === :(->) && length(args) == 1 && !haskey(def, :kwargs)
         args[1]
     else
         :(($(args...),))  # Equivalent to `Expr(:tuple, args...)` but faster
@@ -183,9 +187,9 @@ function combinedef(def::Dict{Symbol,Any})
     end
 
     func = if haskey(def, :body)
-        Expr(def[:head], sig, def[:body])
+        Expr(head, sig, def[:body])
     else
-        Expr(def[:head], name)
+        Expr(head, name)
     end
 
     return func

--- a/src/method.jl
+++ b/src/method.jl
@@ -22,7 +22,7 @@ Unsupported:
 - `:head`: Expression head of the function definition (`:function`, `:(=)`, `:(->)`)
 
 For more complete coverage, consider using [`splitdef`](@ref)
-with [`CodeTracking.definition`](https://github.com/timholy/CodeTracking.jl)).
+with [`CodeTracking.definition`](https://github.com/timholy/CodeTracking.jl).
 
 The dictionary of components returned by `signature` match those returned by
 [`splitdef`](@ref) and include all that are required by [`combinedef`](@ref), except for

--- a/src/method.jl
+++ b/src/method.jl
@@ -1,0 +1,110 @@
+"""
+    signature(meth::Method) -> Dict{Symbol,Any}
+
+Finds the expression for a methods signature as broken up into its various components
+including:
+
+- `:head`: Expression head of the function definition: always `:function`
+- `:name`: Name of the function (not present for anonymous functions)
+- `:params`: Parametric types defined on constructors
+- `:args`: Positional arguments of the function
+- `:kwargs`: Keyword arguments of the function
+- `:rtype`: Return type of the function
+- `:whereparams`: Where parameters
+
+All components listed may not be present in the returned dictionary with the exception of
+`:head` which will always be present.
+
+These are the same components returned by [`splitdef`](@ref) and consumed by
+[`combinedef`](@red), except for the `:body` component which will never be present.
+"""
+function signature(meth::Method)
+    def = Dict{Symbol,Any}()
+    def[:head] = :function
+    def[:name] = meth.name
+
+
+    def[:args] = get_args(meth)
+    def[:whereparams] = get_whereparams(meth)
+
+    return Dict(k=>v for (k, v) in def if !isnothing(v))  # filter out nonfields.
+end
+
+get_slot_sym(meth::Method) = Symbol.(split(meth.slot_syms, '\0'; keepempty=false))
+
+function get_arg_names(meth::Method)
+    slot_syms = get_slot_sym(meth)
+    @assert slot_syms[1] == Symbol("#self#")
+    arg_names = slot_syms[2:meth.nargs]  #nargs includes 1 for #self#
+    return arg_names
+end
+
+"""
+    parameters(type)
+
+extracts the type-parameters of the `type`.
+E.g. `parameters(Foo{A, B, C}) == [A, B, C]`
+"""
+parameters(sig::UnionAll) = parameters(sig.body)
+parameters(sig::DataType) = sig.parameters
+
+function get_arg_types(meth::Method)
+    # First parameter of `sig` is the type of the function itself
+    return parameters(meth.sig)[2:end]
+end
+
+name_of_arg_type(x) = x
+name_of_arg_type(tv::TypeVar) = tv.name
+function name_of_arg_type(x::DataType)
+    name_sym = Symbol(x.name)
+    if isempty(x.parameters)
+        return name_sym
+    else
+        parameter_names = name_of_arg_type.(x.parameters)
+        return :($(name_sym){$(parameter_names...)})
+    end
+end
+function name_of_arg_type(x::UnionAll)
+    name = name_of_arg_type(x.body)
+    whereparam = get_whereparam(x.var)
+    return :($name where $whereparam)
+end
+
+
+
+function get_args(meth::Method)
+    arg_names = get_arg_names(meth)
+    arg_types = get_arg_types(meth)
+    map(arg_names, arg_types) do name, type
+        if type === Any
+            name
+        else
+            :($name::$(name_of_arg_type(type)))
+        end
+    end
+end
+
+function get_whereparam(x::TypeVar)
+    if x.lb === Union{} && x.ub === Any
+        return x.name
+    elseif x.lb === Union{}
+        return :($(x.name) <: $(Symbol(x.ub)))
+    elseif x.ub === Any
+        return :($(x.name) >: $(Symbol(x.lb)))
+    else
+        return :($(Symbol(x.lb)) <: $(x.name) <: $(Symbol(x.ub)))
+    end
+    # TODO other bounds
+end
+
+function get_whereparams(meth::Method)
+    meth.sig isa UnionAll || return nothing
+
+    whereparams = []
+    sig = meth.sig
+    while sig isa UnionAll
+        push!(whereparams, get_whereparam(sig.var))
+        sig = sig.body
+    end
+    return whereparams
+end

--- a/src/method.jl
+++ b/src/method.jl
@@ -21,7 +21,6 @@ These are the same components returned by [`splitdef`](@ref) and required by
 """
 function signature(meth::Method)
     def = Dict{Symbol,Any}()
-    def[:head] = :function
     def[:name] = meth.name
 
 

--- a/src/method.jl
+++ b/src/method.jl
@@ -99,7 +99,6 @@ function get_whereparam(x::TypeVar)
     else
         return :($(Symbol(x.lb)) <: $(x.name) <: $(Symbol(x.ub)))
     end
-    # TODO other bounds
 end
 
 function get_whereparams(meth::Method)

--- a/src/method.jl
+++ b/src/method.jl
@@ -37,7 +37,7 @@ function slot_syms(meth::Method)
 end
 function argument_names(meth::Method)
     slot_syms = get_slot_sym(meth)
-    @assert slot_syms[1] == Symbol("#self#")
+    @assert slot_syms[1] === Symbol("#self#")
     arg_names = slot_syms[2:meth.nargs]  # nargs includes 1 for `#self#`
     return arg_names
 end
@@ -45,7 +45,8 @@ end
 """
     parameters(type)
 
-extracts the type-parameters of the `type`.
+Extracts the type-parameters of the `type`.
+
 ```jldoctest
 julia> parameters(Foo{A, B, C}) == [A, B, C]
 true
@@ -74,7 +75,6 @@ function name_of_arg_type(x::UnionAll)
     whereparam = get_whereparam(x.var)
     return :($name where $whereparam)
 end
-
 
 
 function get_args(meth::Method)

--- a/src/method.jl
+++ b/src/method.jl
@@ -4,19 +4,19 @@
 Finds the expression for a methods signature as broken up into its various components
 including:
 
-- `:head`: Expression head of the function definition: always `:function`
-- `:name`: Name of the function (not present for anonymous functions)
+- `:name`: Name of the function
 - `:params`: Parametric types defined on constructors
 - `:args`: Positional arguments of the function
-- `:rtype`: Return type of the function
 - `:whereparams`: Where parameters
 
-All components listed may not be present in the returned dictionary with the exception of
-`:head` which will always be present.
+All components listed above may not be present in the returned dictionary
 
-Note: keyword arguments are always ignored, right now.
+Right now the following components will never be returned:
+ - `:kwargs`: Keyword arguments of the function
+ - `:rtype`: Return type of the function
+ - `:body`: Function body
 
-These are the same components returned by [`splitdef`](@ref) and consumed by
+These are the same components returned by [`splitdef`](@ref) and required by
 [`combinedef`](@red), except for the `:body` component which will never be present.
 """
 function signature(meth::Method)

--- a/src/method.jl
+++ b/src/method.jl
@@ -69,10 +69,14 @@ function arguments(meth::Method)
     arg_names = argument_names(meth)
     arg_types = argument_types(meth)
     map(arg_names, arg_types) do name, type
-        if type === Any
+        has_name = name !== Symbol("#unused#")
+        type_name = name_of_arg_type(type)
+        if type === Any && has_name
             name
+        elseif has_name
+            :($name::$type_name)
         else
-            :($name::$(name_of_arg_type(type)))
+            :(::$type_name)
         end
     end
 end

--- a/src/method.jl
+++ b/src/method.jl
@@ -1,7 +1,7 @@
 """
     signature(meth::Method) -> Dict{Symbol,Any}
 
-Finds the expression for a methods signature as broken up into its various components
+Finds the expression for a method's signature as broken up into its various components
 including:
 
 - `:name`: Name of the function
@@ -9,7 +9,7 @@ including:
 - `:args`: Positional arguments of the function
 - `:whereparams`: Where parameters
 
-All components listed above may not be present in the returned dictionary
+All components listed above may not be present in the returned dictionary.
 
 Right now the following components will never be returned:
  - `:kwargs`: Keyword arguments of the function
@@ -17,17 +17,17 @@ Right now the following components will never be returned:
  - `:body`: Function body
 
 These are the same components returned by [`splitdef`](@ref) and required by
-[`combinedef`](@red), except for the `:body` component which will never be present.
+[`combinedef`](@ref), except for the `:body` component which will never be present.
 """
 function signature(meth::Method)
-    def = Dict{Symbol,Any}()
+    def = Dict{Symbol, Any}()
     def[:name] = meth.name
 
     def[:args] = arguments(meth)
     def[:whereparams] = where_parameters(meth)
     def[:params] = parameters(meth)
 
-    return Dict(k=>v for (k, v) in def if v !== nothing)  # filter out nonfields.
+    return Dict(k => v for (k, v) in def if v !== nothing)  # filter out nonfields.
 end
 
 function slot_names(meth::Method)

--- a/src/method.jl
+++ b/src/method.jl
@@ -12,7 +12,7 @@ including:
 All components listed above may not be present in the returned dictionary if they are
 not in the function definition.
 
-Limitted support for:
+Limited support for:
 - `:kwargs`: Keyword arguments of the function.
   Only the names will be included, not the default values or type constraints.
 
@@ -24,7 +24,7 @@ Unsupported:
 For more complete coverage, consider using [`splitdef`](@ref)
 with [`CodeTracking.definition`](https://github.com/timholy/CodeTracking.jl)).
 
-The dictionary of compenents returned by `signature` match those returned by
+The dictionary of components returned by `signature` match those returned by
 [`splitdef`](@ref) and include all that are required by [`combinedef`](@ref), except for
 the `:body` component.
 """

--- a/src/method.jl
+++ b/src/method.jl
@@ -8,12 +8,13 @@ including:
 - `:name`: Name of the function (not present for anonymous functions)
 - `:params`: Parametric types defined on constructors
 - `:args`: Positional arguments of the function
-- `:kwargs`: Keyword arguments of the function
 - `:rtype`: Return type of the function
 - `:whereparams`: Where parameters
 
 All components listed may not be present in the returned dictionary with the exception of
 `:head` which will always be present.
+
+Note: keyword arguments are always ignored, right now.
 
 These are the same components returned by [`splitdef`](@ref) and consumed by
 [`combinedef`](@red), except for the `:body` component which will never be present.
@@ -27,11 +28,15 @@ function signature(meth::Method)
     def[:args] = get_args(meth)
     def[:whereparams] = get_whereparams(meth)
 
-    return Dict(k=>v for (k, v) in def if !isnothing(v))  # filter out nonfields.
+    return Dict(k=>v for (k, v) in def if v !== nothing)  # filter out nonfields.
 end
 
-get_slot_sym(meth::Method) = Symbol.(split(meth.slot_syms, '\0'; keepempty=false))
-
+function get_slot_sym(meth::Method)
+    # In 1.3 can do:
+    # Symbol.(split(meth.slot_syms, '\0'; keepempty=false))
+    ci = Base.uncompressed_ast(meth)
+    return ci.slotnames
+end
 function get_arg_names(meth::Method)
     slot_syms = get_slot_sym(meth)
     @assert slot_syms[1] == Symbol("#self#")

--- a/src/method.jl
+++ b/src/method.jl
@@ -23,23 +23,22 @@ function signature(meth::Method)
     def = Dict{Symbol,Any}()
     def[:name] = meth.name
 
-
     def[:args] = get_args(meth)
     def[:whereparams] = get_whereparams(meth)
 
     return Dict(k=>v for (k, v) in def if v !== nothing)  # filter out nonfields.
 end
 
-function get_slot_sym(meth::Method)
+function slot_syms(meth::Method)
     # In 1.3 can do:
     # Symbol.(split(meth.slot_syms, '\0'; keepempty=false))
     ci = Base.uncompressed_ast(meth)
     return ci.slotnames
 end
-function get_arg_names(meth::Method)
+function argument_names(meth::Method)
     slot_syms = get_slot_sym(meth)
     @assert slot_syms[1] == Symbol("#self#")
-    arg_names = slot_syms[2:meth.nargs]  #nargs includes 1 for #self#
+    arg_names = slot_syms[2:meth.nargs]  # nargs includes 1 for `#self#`
     return arg_names
 end
 
@@ -47,7 +46,9 @@ end
     parameters(type)
 
 extracts the type-parameters of the `type`.
-E.g. `parameters(Foo{A, B, C}) == [A, B, C]`
+```jldoctest
+julia> parameters(Foo{A, B, C}) == [A, B, C]
+true
 """
 parameters(sig::UnionAll) = parameters(sig.body)
 parameters(sig::DataType) = sig.parameters
@@ -88,7 +89,7 @@ function get_args(meth::Method)
     end
 end
 
-function get_whereparam(x::TypeVar)
+function where_parameters(x::TypeVar)
     if x.lb === Union{} && x.ub === Any
         return x.name
     elseif x.lb === Union{}

--- a/src/type_utils.jl
+++ b/src/type_utils.jl
@@ -1,0 +1,11 @@
+"""
+    parameters(type)
+
+Extracts the type-parameters of the `type`.
+
+```jldoctest
+julia> parameters(Foo{A, B, C}) == [A, B, C]
+true
+"""
+parameters(sig::UnionAll) = parameters(sig.body)
+parameters(sig::DataType) = sig.parameters

--- a/src/type_utils.jl
+++ b/src/type_utils.jl
@@ -6,6 +6,7 @@ Extracts the type-parameters of the `type`.
 ```jldoctest
 julia> parameters(Foo{A, B, C}) == [A, B, C]
 true
+```
 """
 parameters(sig::UnionAll) = parameters(sig.body)
 parameters(sig::DataType) = sig.parameters

--- a/src/type_utils.jl
+++ b/src/type_utils.jl
@@ -3,10 +3,7 @@
 
 Extracts the type-parameters of the `type`.
 
-```jldoctest
-julia> parameters(Foo{A, B, C}) == [A, B, C]
-true
-```
+e.g. `parameters(Foo{A, B, C}) == [A, B, C]`
 """
 parameters(sig::UnionAll) = parameters(sig.body)
 parameters(sig::DataType) = sig.parameters

--- a/test/function.jl
+++ b/test/function.jl
@@ -786,6 +786,7 @@ function_form(short::Bool) = string(short ? "short" : "long", "-form")
 
         d = splitdef(expr)
         delete!(d, :head)
+        @assert !haskey(d, :head)
 
         c_expr = combinedef(d)
         @test c_expr == expr

--- a/test/function.jl
+++ b/test/function.jl
@@ -780,6 +780,17 @@ function_form(short::Bool) = string(short ? "short" : "long", "-form")
         end
     end
 
+    @testset "combinedef with no ``:head`" begin
+        # should default to `:function`
+        f, expr = @audit function f() end
+
+        d = splitdef(expr)
+        delete!(d, :head)
+
+        c_expr = combinedef(d)
+        @test c_expr == expr
+    end
+
     @testset "invalid definitions" begin
         # Invalid function type
         @test_splitdef_invalid Expr(:block)

--- a/test/function.jl
+++ b/test/function.jl
@@ -780,7 +780,7 @@ function_form(short::Bool) = string(short ? "short" : "long", "-form")
         end
     end
 
-    @testset "combinedef with no ``:head`" begin
+    @testset "combinedef with no `:head`" begin
         # should default to `:function`
         f, expr = @audit function f() end
 

--- a/test/method.jl
+++ b/test/method.jl
@@ -130,8 +130,9 @@ end
         )
     end
 
-
-    @testset "Constructors (basic)" begin
+    # Only test on 1.3 because of issues with declaring structs in 1.0-1.2
+    # TODO: https://github.com/invenia/ExprTools.jl/issues/7
+    VERSION >= v"1.3" && @testset "Constructors (basic)" begin
         # demo type for testing on
         struct NoParamStruct
             x
@@ -163,7 +164,9 @@ end
         )
     end
 
-    @testset "params (via Constructors with type params)" begin
+    # Only test on 1.3 because of issues with declaring structs in 1.0-1.2
+    # TODO: https://github.com/invenia/ExprTools.jl/issues/7
+    VERSION >= v"1.3" && @testset "params (via Constructors with type params)" begin
         struct OneParamStruct{T}
             x::T
         end

--- a/test/method.jl
+++ b/test/method.jl
@@ -81,17 +81,17 @@ end
         # this generates something that should be the same as what `signature(f16)` does
         # but with a gensym'd variable name
         f16_alt(x::Array{<:Real, 1}) = 2x
-        f16_alt_sig = signature(first(methods(f16_alt)))
+        f16_alt_sig = signature(only_method(f16_alt))
         @test f16_alt_sig[:name] == :f16_alt
         @test occursin(  # Hack to deal with gensymed name. Make it a string and use regex
-            r"^Expr\[:\(x::\(Array\{var\"(.*?)\", 1\} where var\"\1\" <: Real\)\)\]$",
+            r"^\QExpr[:(x::(Array{var\"\E(.*?)\Q\", 1} where var\"1\" <: Real))]\E$",
             string(f16_alt_sig[:args])
         )
     end
 
     @testset "anon functions" begin
         @test_signature (x) -> x  # no args
-        @test_signature (x)->2x
+        @test_signature (x) -> 2x
 
         @test_signature ((::T) where T) -> 0   # Anonymous parameter
 
@@ -163,7 +163,7 @@ end
         )
     end
 
-    @testset "params (via Constructors with type params" begin
+    @testset "params (via Constructors with type params)" begin
         struct OneParamStruct{T}
             x::T
         end

--- a/test/method.jl
+++ b/test/method.jl
@@ -26,7 +26,6 @@ end
     only_method(f, [typ])
 
 Return the only method of `f`,
-filtering by those accepts the types indicated by `typ` if it is provided.
 Similar to `only(methods(f, typ))` in julia 1.4.
 """
 function only_method(f, typ=Tuple{Vararg{Any}})

--- a/test/method.jl
+++ b/test/method.jl
@@ -1,6 +1,6 @@
 macro check_signature(function_def_expr)
     _target = splitdef(function_def_expr)
-    _target[:head] = :function  # always make it a :function
+    delete!(_target, :head) # never look at :head
     delete!(_target, :body) # never looking at body
     ret = quote
         fun = $(esc(function_def_expr))

--- a/test/method.jl
+++ b/test/method.jl
@@ -2,12 +2,12 @@ macro test_signature(function_def_expr, method=nothing)
     _target = splitdef(function_def_expr)
     return quote
         fun = $(esc(function_def_expr))
-        meth = if ($method === nothing)
+        m = if ($method === nothing)
             only_method(fun)
         else
             $(esc(method))
         end
-        sig = signature(meth)
+        sig = signature(m)
         test_matches(sig, $(_target))
     end
 end
@@ -29,11 +29,11 @@ Return the only method of `f`,
 Similar to `only(methods(f, typ))` in julia 1.4.
 """
 function only_method(f, typ=Tuple{Vararg{Any}})
-    meths = methods(f, typ)
-    if length(meths) !== 1
-        error("not just one method matches the given types. Found $(length(meths))")
+    ms = methods(f, typ)
+    if length(ms) !== 1
+        error("not just one method matches the given types. Found $(length(ms))")
     end
-    return first(meths)
+    return first(ms)
 end
 
 
@@ -119,7 +119,7 @@ end
     @testset "kwargs" begin  # We do not support them right now
         #Following is broken:
         #@test_signature kwargs17(x; y=3x) = 2x
-
+        kwargs17(x; y=3x) = 2x
         # at least be sure we get the rest right:
         test_matches(
             signature(only_method(kwargs17)),

--- a/test/method.jl
+++ b/test/method.jl
@@ -173,7 +173,7 @@ end
 
     # Only test on 1.3 because of issues with declaring structs in 1.0-1.2
     # TODO: https://github.com/invenia/ExprTools.jl/issues/7
-    VERSION >= v"1.3" && @testset "Constructors (basic)" begin
+    VERSION >= v"1.3" && @eval @testset "Constructors (basic)" begin
         # demo type for testing on
         struct NoParamStruct
             x
@@ -207,7 +207,7 @@ end
 
     # Only test on 1.3 because of issues with declaring structs in 1.0-1.2
     # TODO: https://github.com/invenia/ExprTools.jl/issues/7
-    VERSION >= v"1.3" && @testset "params (via Constructors with type params)" begin
+    VERSION >= v"1.3" && @eval @testset "params (via Constructors with type params)" begin
         struct OneParamStruct{T}
             x::T
         end

--- a/test/method.jl
+++ b/test/method.jl
@@ -94,8 +94,6 @@ end
         @test_signature (x) -> 2x
 
         @test_signature ((::T) where T) -> 0   # Anonymous parameter
-
-
     end
 
     @testset "vararg" begin

--- a/test/method.jl
+++ b/test/method.jl
@@ -21,6 +21,10 @@ function test_matches(candidate::AbstractDict, target::Dict)
         @test target[:whereparams] == get(candidate, :whereparams, nothing)
     end
     haskey(target, :kwargs) && @test target[:kwargs] == get(candidate, :kwargs, nothing)
+
+    # TODO: support return value declaration in signature
+    # See https://github.com/invenia/ExprTools.jl/issues/5
+    haskey(target, :rtype) && @test_broken target[:rtype] == get(candidate, :rtype, nothing)
     return nothing
 end
 
@@ -155,6 +159,16 @@ end
                 :kwargs => [:y],  # should be `[Expr(:kw, :(y::Int32), 4)]
             )
         )
+    end
+
+    @testset "Return Type" begin
+        # These all hit the `@test_broken`
+        @test_signature rt1(x)::Int32 = 2x
+
+        # need to use long-form becase https://github.com/JuliaLang/julia/issues/35471
+        @test_signature function rt2(x::T)::T where T
+            return 2x
+        end
     end
 
     # Only test on 1.3 because of issues with declaring structs in 1.0-1.2

--- a/test/method.jl
+++ b/test/method.jl
@@ -17,8 +17,9 @@ function test_matches(candidate::AbstractDict, target::Dict)
     haskey(target, :name) && @test target[:name] == get(candidate, :name, nothing)
     haskey(target, :params) && @test target[:params] == get(candidate, :params, nothing)
     haskey(target, :args) && @test target[:args] == get(candidate, :args, nothing)
-    haskey(target, :whereparams) &&
+    if haskey(target, :whereparams)
         @test target[:whereparams] == get(candidate, :whereparams, nothing)
+    end
     return nothing
 end
 

--- a/test/method.jl
+++ b/test/method.jl
@@ -60,6 +60,11 @@ end
         @check_signature (x)->2x
     end
 
+    @testset "vararg" begin
+        @check_signature f18(xs...) = 2
+        @check_signature f19(xs::VarArg{Any, N} where N)
+    end
+
     @testset "kwargs" begin  # We do not support them right now
 
         #Following is broken:

--- a/test/method.jl
+++ b/test/method.jl
@@ -1,4 +1,4 @@
-macro check_signature(function_def_expr)
+macro test_signature(function_def_expr)
     _target = splitdef(function_def_expr)
     delete!(_target, :head) # never look at :head
     delete!(_target, :body) # never looking at body

--- a/test/method.jl
+++ b/test/method.jl
@@ -84,7 +84,7 @@ end
         f16_alt_sig = signature(only_method(f16_alt))
         @test f16_alt_sig[:name] == :f16_alt
         @test occursin(  # Hack to deal with gensymed name. Make it a string and use regex
-            r"^\QExpr[:(x::(Array{var\"\E(.*?)\Q\", 1} where var\"1\" <: Real))]\E$",
+            r"^\QExpr[:(x::(Array{\E(.*?)\Q, 1} where \E\1\Q <: Real))]\E$",
             string(f16_alt_sig[:args])
         )
     end

--- a/test/method.jl
+++ b/test/method.jl
@@ -1,0 +1,68 @@
+macro check_signature(function_def_expr)
+    _target = splitdef(function_def_expr)
+    _target[:head] = :function  # always make it a :function
+    delete!(_target, :body) # never looking at body
+    ret = quote
+        fun = $(esc(function_def_expr))
+        meths = methods(fun)
+        target = $(_target)
+        if length(meths) > 1
+            error("can only check signatures of functions with only one method")
+        end
+        sig = signature(first(meths))
+    end
+    for key in keys(_target)
+        # interpolate in the `key` to make test results easy to read
+        push!(
+            ret.args,
+            :(@test target[$(QuoteNode(key))] == get(sig, $(QuoteNode(key)), nothing)),
+        )
+    end
+    return ret
+end
+
+@testset "method.jl: signature" begin
+    @testset "Basics" begin
+        @check_signature f1(x) = 2x
+        @check_signature f2(x::Int64) = 2x
+        @check_signature f3(x::Int64, y) = 2x
+    end
+
+    @testset "Whereparams" begin
+        @check_signature f4(x::T, y::T) where T = 2x
+
+        @check_signature f5(x::S, y::T) where {S,T} = 2x
+        @check_signature f6(x::S, y::T) where {T,S} = 2x
+        @check_signature f7(x::S, y::T) where T where S = 2x
+    end
+
+    @testset "Whereparams with constraints" begin
+        @check_signature f8(x::S) where S<:Integer = 2x
+        @check_signature f9(x::S, y::S) where S<:Integer = 2x
+        @check_signature f10(x::S, y::T) where {S<:Integer, T<:Real} = 2x
+        @check_signature f11(x::S, y::Int64) where S<:Integer = 2x
+
+        @check_signature f12(x::S) where {S>:Integer} = 2x
+        @check_signature f13(x::S) where Integer<:S<:Number = 2x
+    end
+
+    @testset "Arg types with type-parameters" begin
+        @check_signature f14(x::Array{Int64, 1}) = 2x
+        @check_signature f15(x::Array{T, 1}) where T = 2x
+
+        # Note: we don't test: `f16(x::Array{<:Real, 1}) = 2x` as it lowers to same
+        # method as below, but has a different AST according to `splitdef` so we can't
+        # generate a solution that would unlower to two different AST for same method
+        @check_signature f16(x::Array{T, 1} where T<:Real) = 2x
+    end
+
+    @testset "anon functions" begin
+        @check_signature (x)->2x
+    end
+
+    @testset "kwargs" begin  # We do not support them right now
+
+        #Following is broken:
+        #@check_signature f17(x; y=3x) = 2x
+    end
+end

--- a/test/method.jl
+++ b/test/method.jl
@@ -26,7 +26,7 @@ end
     only_method(f, [typ])
 
 Return the only method of `f`,
-Similar to `only(methods(f, typ))` in julia 1.4.
+Similar to `only(methods(f, typ))` in Julia 1.4.
 """
 function only_method(f, typ=Tuple{Vararg{Any}})
     ms = methods(f, typ)

--- a/test/method.jl
+++ b/test/method.jl
@@ -21,57 +21,73 @@ macro test_signature(function_def_expr)
     return ret
 end
 
+
+
+
 @testset "method.jl: signature" begin
     @testset "Basics" begin
-        @check_signature f1(x) = 2x
-        @check_signature f2(x::Int64) = 2x
-        @check_signature f3(x::Int64, y) = 2x
+        @test_signature f1(x) = 2x
+        @test_signature f2(x::Int64) = 2x
+        @test_signature f3(x::Int64, y) = 2x
+
+        @test_signature bf4(::Int) = 2x
     end
 
     @testset "Whereparams" begin
-        @check_signature f4(x::T, y::T) where T = 2x
+        @test_signature f4(x::T, y::T) where T = 2x
 
-        @check_signature f5(x::S, y::T) where {S,T} = 2x
-        @check_signature f6(x::S, y::T) where {T,S} = 2x
-        @check_signature f7(x::S, y::T) where T where S = 2x
+        @test_signature f5(x::S, y::T) where {S,T} = 2x
+        @test_signature f6(x::S, y::T) where {T,S} = 2x
+        @test_signature f7(x::S, y::T) where T where S = 2x
     end
 
     @testset "Whereparams with constraints" begin
-        @check_signature f8(x::S) where S<:Integer = 2x
-        @check_signature f9(x::S, y::S) where S<:Integer = 2x
-        @check_signature f10(x::S, y::T) where {S<:Integer, T<:Real} = 2x
-        @check_signature f11(x::S, y::Int64) where S<:Integer = 2x
+        @test_signature f8(x::S) where S<:Integer = 2x
+        @test_signature f9(x::S, y::S) where S<:Integer = 2x
+        @test_signature f10(x::S, y::T) where {S<:Integer, T<:Real} = 2x
+        @test_signature f11(x::S, y::Int64) where S<:Integer = 2x
 
-        @check_signature f12(x::S) where {S>:Integer} = 2x
-        @check_signature f13(x::S) where Integer<:S<:Number = 2x
+        @test_signature f12(x::S) where {S>:Integer} = 2x
+        @test_signature f13(x::S) where Integer<:S<:Number = 2x
     end
 
     @testset "Arg types with type-parameters" begin
-        @check_signature f14(x::Array{Int64, 1}) = 2x
-        @check_signature f15(x::Array{T, 1}) where T = 2x
+        @test_signature f14(x::Array{Int64, 1}) = 2x
+        @test_signature f15(x::Array{T, 1}) where T = 2x
 
         # Note: we don't test: `f16(x::Array{<:Real, 1}) = 2x` as it lowers to same
         # method as below, but has a different AST according to `splitdef` so we can't
         # generate a solution that would unlower to two different AST for same method
-        @check_signature f16(x::Array{T, 1} where T<:Real) = 2x
+        @test_signature f16(x::Array{T, 1} where T<:Real) = 2x
+
+        #==
+        # noncanonical form works
+        old_sig = signature(first(methods(f16)))
+        f16(x::Array{<:Real, 1} = 2x  # redefine it
+        @assert length(methods(f16)) == 1  # no new method should have been created
+        new_sig = signature(first(methods(f16)))
+        ==#
     end
 
     @testset "anon functions" begin
-        @check_signature (x)->2x
+        @test_signature (x)->2x
+        # following is broken:
+        # @test_signature ((::T) where T) -> 0
+
     end
 
     @testset "vararg" begin
         # we don't check `f18(xs...) = 2` as it lowers to the same method as below
         # but has a different AST according to `splitdef` so we can't
         # generate a solution that would unlower to two different AST for same method.
-        @check_signature f17(xs::Vararg{Any, N} where N) = 2
+        @test_signature f17(xs::Vararg{Any, N} where N) = 2
 
-        @check_signature f18(xs::Vararg{Int64, N} where N) = 2
-        @check_signature f19(x, xs::Vararg{Any, N} where N) = 2x
+        @test_signature f18(xs::Vararg{Int64, N} where N) = 2
+        @test_signature f19(x, xs::Vararg{Any, N} where N) = 2x
     end
 
     @testset "kwargs" begin  # We do not support them right now
         #Following is broken:
-        #@check_signature f17(x; y=3x) = 2x
+        #@test_signature f17(x; y=3x) = 2x
     end
 end

--- a/test/method.jl
+++ b/test/method.jl
@@ -29,8 +29,12 @@ end
         @test_signature f1(x) = 2x
         @test_signature f2(x::Int64) = 2x
         @test_signature f3(x::Int64, y) = 2x
+    end
 
-        @test_signature bf4(::Int) = 2x
+    @testset "missing argnames" begin
+        @test_signature ma1(::Int32) = 2x
+        @test_signature ma2(::Int32, ::Bool) = 2x
+        @test_signature ma3(x, ::Int32) = 2x
     end
 
     @testset "Whereparams" begin
@@ -91,3 +95,26 @@ end
         #@test_signature f17(x; y=3x) = 2x
     end
 end
+
+#==
+
+julia> signature(first(methods(((::T) where T) -> 0)))  # Anonymous parameter
+Dict{Symbol,Any} with 4 entries:
+  :name        => Symbol("#35")
+  :args        => Expr[:(var"#unused#"::T)]
+  :head        => :function
+  :whereparams => Any[:T]
+
+julia> signature(first(methods((x=1) -> x)))  # Missing arg
+Dict{Symbol,Any} with 3 entries:
+  :name => Symbol("#42")
+  :args => Union{Expr, Symbol}[]
+  :head => :function
+
+julia> signature(first(methods(Rational{Int8}, (Integer,))))  # No `:params`
+Dict{Symbol,Any} with 4 entries:
+  :name        => :Rational
+  :args        => Expr[:(x::Integer)]
+  :head        => :function
+  :whereparams => Any[:(T <: Integer)]
+  ==#

--- a/test/method.jl
+++ b/test/method.jl
@@ -61,12 +61,16 @@ end
     end
 
     @testset "vararg" begin
-        @check_signature f18(xs...) = 2
-        @check_signature f19(xs::VarArg{Any, N} where N)
+        # we don't check `f18(xs...) = 2` as it lowers to the same method as below
+        # but has a different AST according to `splitdef` so we can't
+        # generate a solution that would unlower to two different AST for same method.
+        @check_signature f17(xs::Vararg{Any, N} where N) = 2
+
+        @check_signature f18(xs::Vararg{Int64, N} where N) = 2
+        @check_signature f19(x, xs::Vararg{Any, N} where N) = 2x
     end
 
     @testset "kwargs" begin  # We do not support them right now
-
         #Following is broken:
         #@check_signature f17(x; y=3x) = 2x
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,5 @@ using Test
 
 @testset "ExprTools.jl" begin
     include("function.jl")
+    include("method.jl")
 end


### PR DESCRIPTION
Goal is to generate a dictionary like is returned from `splitdef` when  given only a `Method` object.
So that you can manipulate it,
and then call `combinedef` on the result, to get the AST of the code you want to eval.