### PR TITLE
Deal with (x; y=0) -> ... pattern

### DIFF
--- a/src/function.jl
+++ b/src/function.jl
@@ -102,7 +102,11 @@ function splitdef(ex::Expr; throw::Bool=true)
             if !haskey(def, :args)
                 def[:args] = [arg]
             elseif !haskey(def, :kwargs)
-                def[:kwargs] = arg isa Symbol ? [arg] : [:($(Expr(:kw, arg.args...)))]
+                if arg isa Expr && arg.head == :(=)
+                    def[:kwargs] = [:($(Expr(:kw, arg.args...)))]
+                else
+                    def[:kwargs] = [arg]
+                end
             else
                 return invalid_def("an invalid block expression as arguments")
             end

--- a/src/function.jl
+++ b/src/function.jl
@@ -102,7 +102,7 @@ function splitdef(ex::Expr; throw::Bool=true)
             if !haskey(def, :args)
                 def[:args] = [arg]
             elseif !haskey(def, :kwargs)
-                def[:kwargs] = [arg]
+                def[:kwargs] = arg isa Symbol ? [arg] : [:($(Expr(:kw, arg.args...)))]
             else
                 return invalid_def("an invalid block expression as arguments")
             end

--- a/test/function.jl
+++ b/test/function.jl
@@ -567,6 +567,29 @@ function_form(short::Bool) = string(short ? "short" : "long", "-form")
             @test strip_lineno!(c_expr) == strip_lineno!(expr)
         end
 
+        @testset "(x; y = 0, _...)" begin
+            f, expr = if short
+                @audit (x; y = 0, _...) -> (x, y)
+            else
+                @audit function (x; y = 0, _...); (x, y) end
+            end
+            @test length(methods(f)) == 1
+            @test f(0) == (0, 0)
+            @test f(0, y=1) == (0, 1)
+            @test f(0, y=1, z=2) == (0, 1)
+
+            # Note: the semi-colon is missing from the expression
+            d = splitdef(expr)
+            @test keys(d) == Set([:head, :args, :kwargs, :body])
+            @test d[:args] == [:x]
+            @test d[:kwargs] == [Expr(:kw, :y, 0), :(_...)]
+
+            c_expr = combinedef(d)
+            expr = Expr(:->, Expr(:tuple, Expr(:parameters, Expr(:kw, :y, 0), :(_...)), :x), Expr(:block, :((x, y))))
+            expr.head = short ? :-> : :function
+            @test strip_lineno!(c_expr) == strip_lineno!(expr)
+        end
+
         @testset "Expr(:block, :x, :y)" begin
             expr = Expr(:->, Expr(:block, :x, :y), Expr(:block, :((x, y))))
             expr.head = short ? :-> : :function


### PR DESCRIPTION
Closes #8 

Before this PR,   the kwarg `y=0` in `splitdef((x; y=0) -> ...)` was being injected as `:(y=0)` instead of `Expr(:kw, y, 0)` into the Dict. This fix is done via special-casing this pattern.