### PR TITLE
fix whereparams that are unions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExprTools"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 authors = ["Invenia Technical Computing"]
-version = "0.1.1"
+version = "0.1.2"
 
 [compat]
 julia = "1"

--- a/test/method.jl
+++ b/test/method.jl
@@ -72,6 +72,8 @@ end
 
         @test_signature f12(x::S) where {S>:Integer} = 2x
         @test_signature f13(x::S) where Integer<:S<:Number = 2x
+
+        @test_signature f_where_union(x::T) where T<:Union{Bool, Int32} = 2x
     end
 
     @testset "Arg types with type-parameters" begin


### PR DESCRIPTION
I think I need this for
https://github.com/invenia/Nabla.jl/pull/189

Before it would get this wrong:

```julia
julia> foo(x::T) where T<:Union{Float32,Bool} = 2x
foo (generic function with 1 method)


julia> signature(@which foo(true))
Dict{Symbol,Any} with 3 entries:
  :name        => :foo
  :args        => Expr[:(x::T)]
  :whereparams => Any[:(T <: var"Union{Bool, Float32}")]

julia> splitdef(:(foo(x::T) where T<:Union{Float32,Bool} = 2x))
Dict{Symbol,Any} with 5 entries:
  :args        => Any[:(x::T)]
  :body        => quote…
  :name        => :foo
  :head        => :(=)
  :whereparams => Any[:(T <: Union{Float32, Bool})]
```

This fixes it so that `signature` matches `splitdef`