### PR TITLE
Overhaul name_of_type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExprTools"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 authors = ["Invenia Technical Computing"]
-version = "0.1.2"
+version = "0.1.3"
 
 [compat]
 julia = "1"

--- a/src/method.jl
+++ b/src/method.jl
@@ -108,11 +108,7 @@ function name_of_type(x::UnionAll)
     end
 
     name = name_of_type(x)
-    if isempty(where_params)
-        return name
-    else
-        return :($name where {$(where_params...)})
-    end
+    return :($name where {$(where_params...)})
 end
 
 function name_of_type(x::Union)

--- a/src/method.jl
+++ b/src/method.jl
@@ -103,7 +103,7 @@ function name_of_type(x::UnionAll)
     # `foo{T,A} where {T, A}`` rather than the longer: `(foo{T,A} where T) where A`
     where_params = []
     while x isa UnionAll
-        push!(where_params, where_parameter1(x.var))
+        push!(where_params, where_constraint(x.var))
         x = x.body
     end
 
@@ -132,8 +132,7 @@ function arguments(m::Method)
     end
 end
 
-# type-vars can only show up attached to UnionAlls.
-function where_parameter1(x::TypeVar)
+function where_constraint(x::TypeVar)
     if x.lb === Union{} && x.ub === Any
         return x.name
     elseif x.lb === Union{}
@@ -150,7 +149,7 @@ where_parameters(sig) = nothing
 function where_parameters(sig::UnionAll)
     whereparams = []
     while sig isa UnionAll
-        push!(whereparams, where_parameter1(sig.var))
+        push!(whereparams, where_constraint(sig.var))
         sig = sig.body
     end
     return whereparams

--- a/src/method.jl
+++ b/src/method.jl
@@ -78,8 +78,8 @@ function name_of_type(x::Core.TypeName)
     end
 end
 
-name_of_type(x::Symbol) = x  # Literal
-function name_of_type(x::T) where T  # Literal
+name_of_type(x::Symbol) = QuoteNode(x)  # Literal type-param e.g. `Val{:foo}`
+function name_of_type(x::T) where T  # Literal type-param e.g. `Val{1}`
     # it is a bug in our implementation if this error every gets hit.
     isbits(x) || throw(DomainError((x, T), "not a valid type-param"))
     return x

--- a/src/method.jl
+++ b/src/method.jl
@@ -29,12 +29,10 @@ The dictionary of components returned by `signature` match those returned by
 the `:body` component.
 """
 function signature(m::Method)
-    explicit_tvars = ExprTools.extract_tvars(m)
-
     def = Dict{Symbol, Any}()
     def[:name] = m.name
 
-    def[:args] = arguments(m, explicit_tvars)
+    def[:args] = arguments(m)
     def[:whereparams] = where_parameters(m)
     def[:params] = type_parameters(m)
     def[:kwargs] = kwargs(m)
@@ -69,7 +67,7 @@ function name_of_module(m::Module)
         return :($(name_of_module(parentmodule(m))).$(nameof(m)))
     end
 end
-function name_of_type(x::Core.TypeName, _)
+function name_of_type(x::Core.TypeName)
     #TODO: could let user pass this in, then we could be using what is inscope for them
     # but this is not important as we will give a correct (if overly verbose) output as is.
     from = DummyThatHasOnlyDefaultImports
@@ -80,38 +78,36 @@ function name_of_type(x::Core.TypeName, _)
     end
 end
 
-name_of_type(x::Symbol, _) = x  # Literal
-function name_of_type(x::T, _) where T  # Literal
+name_of_type(x::Symbol) = x  # Literal
+function name_of_type(x::T) where T  # Literal
     # it is a bug in our implementation if this error every gets hit.
     isbits(x) || throw(DomainError((x, T), "not a valid type-param"))
     return x
 end
-name_of_type(tv::TypeVar, _) = tv.name
-function name_of_type(x::DataType, explict_tvars=Core.TypeVar[])
-    name = name_of_type(x.name, explict_tvars)
+name_of_type(tv::TypeVar) = tv.name
+function name_of_type(x::DataType)
+    name = name_of_type(x.name)
     # because tuples are varadic in number of type parameters having no parameters does not
     # mean you should not write the `{}`, so we special case them here.
     if isempty(x.parameters) && x != Tuple{}
         return name
     else
-        parameter_names = map(t->name_of_type(t, explict_tvars), x.parameters)
+        parameter_names = map(name_of_type, x.parameters)
         return :($(name){$(parameter_names...)})
     end
 end
 
 
-function name_of_type(x::UnionAll, explict_tvars=Core.TypeVar[])
+function name_of_type(x::UnionAll)
     # we do nested union all unwrapping so we can make the more compact:
     # `foo{T,A} where {T, A}`` rather than the longer: `(foo{T,A} where T) where A`
     where_params = []
     while x isa UnionAll
-        if x.var ∉ explict_tvars
-            push!(where_params, where_parameter1(x.var))
-        end
+        push!(where_params, where_parameter1(x.var))
         x = x.body
     end
 
-    name = name_of_type(x, explict_tvars)
+    name = name_of_type(x)
     if isempty(where_params)
         return name
     else
@@ -119,17 +115,17 @@ function name_of_type(x::UnionAll, explict_tvars=Core.TypeVar[])
     end
 end
 
-function name_of_type(x::Union, explict_tvars=Core.TypeVar[])
-    parameter_names = map(t->name_of_type(t, explict_tvars), Base.uniontypes(x))
+function name_of_type(x::Union)
+    parameter_names = map(name_of_type, Base.uniontypes(x))
     return :(Union{$(parameter_names...)})
 end
 
-function arguments(m::Method, explicit_tvars=Core.TypeVar[])
+function arguments(m::Method)
     arg_names = argument_names(m)
     arg_types = argument_types(m)
     map(arg_names, arg_types) do name, type
         has_name = name !== Symbol("#unused#")
-        type_name = name_of_type(type, explicit_tvars)
+        type_name = name_of_type(type)
         if type === Any && has_name
             name
         elseif has_name
@@ -141,7 +137,6 @@ function arguments(m::Method, explicit_tvars=Core.TypeVar[])
 end
 
 # type-vars can only show up attached to UnionAlls.
-# so when showing name of type for bounds don't need to remove any `explicit_tvars`
 function where_parameter1(x::TypeVar)
     if x.lb === Union{} && x.ub === Any
         return x.name
@@ -165,19 +160,6 @@ function where_parameters(sig::UnionAll)
     return whereparams
 end
 
-# type-space version of where_parameters
-extract_tvars(m::Method) = extract_tvars(m.sig)
-extract_tvars(sig) = Core.TypeVar[]
-function extract_tvars(sig::UnionAll)
-    tvars = Core.TypeVar[]
-    while sig isa UnionAll
-        push!(tvars, sig.var)
-        sig = sig.body
-    end
-    return tvars
-end
-
-
 type_parameters(m::Method) = type_parameters(m.sig)
 function type_parameters(sig)
     typeof_type = first(parameters(sig))  # will be e.g Type{Foo{P}} if it has any parameters
@@ -185,7 +167,7 @@ function type_parameters(sig)
 
     function_type = first(parameters(typeof_type))  # will be e.g. Foo{P}
     parameter_types = parameters(function_type)
-    return [name_of_type(type, Core.TypeVar[]) for type in parameter_types]
+    return map(name_of_type, parameter_types)
 end
 
 function kwargs(m::Method)

--- a/src/method.jl
+++ b/src/method.jl
@@ -183,12 +183,3 @@ function kwarg_names(m::Method)
     !isdefined(mt, :kwsorter) && return []  # no kwsorter means no keywords for sure.
     return Base.kwarg_decl(m, typeof(mt.kwsorter))
 end
-
-
-#==
-Hard case:
-Base.ReshapedArray{T,N,A,Tuple} where A<:AbstractUnitRange where N where T
-
-MWE:
-ExprTools.name_of_type(Tuple{})
-==#

--- a/src/method.jl
+++ b/src/method.jl
@@ -58,7 +58,7 @@ function argument_types(sig)
     return parameters(sig)[2:end]
 end
 
-module DummyThatHasOnlyDefaultImports end  # for working out visability
+module DummyThatHasOnlyDefaultImports end  # for working out visibility
 
 function name_of_module(m::Module)
     if Base.is_root_module(m)
@@ -68,7 +68,7 @@ function name_of_module(m::Module)
     end
 end
 function name_of_type(x::Core.TypeName)
-    #TODO: could let user pass this in, then we could be using what is inscope for them
+    # TODO: could let user pass this in, then we could be using what is inscope for them
     # but this is not important as we will give a correct (if overly verbose) output as is.
     from = DummyThatHasOnlyDefaultImports
     if Base.isvisible(x.name, x.module, from)  # avoid qualifying things that are in scope
@@ -80,7 +80,7 @@ end
 
 name_of_type(x::Symbol) = QuoteNode(x)  # Literal type-param e.g. `Val{:foo}`
 function name_of_type(x::T) where T  # Literal type-param e.g. `Val{1}`
-    # it is a bug in our implementation if this error every gets hit.
+    # If this error is thrown, there is an issue with out implementation
     isbits(x) || throw(DomainError((x, T), "not a valid type-param"))
     return x
 end

--- a/test/method.jl
+++ b/test/method.jl
@@ -50,6 +50,14 @@ end
         @test_signature basic4() = 2
     end
 
+    @testset "Tuple{}" begin
+        @test_signature empty_tuple_constraint(x::Tuple{}) = 2
+    end
+
+    @testset "Scope Qualification" begin
+        @test_signature qualified_constraint(x::Base.Threads.SpinLock) = 2
+    end
+
     @testset "missing argnames" begin
         @test_signature ma1(::Int32) = 2x
         @test_signature ma2(::Int32, ::Bool) = 2x

--- a/test/method.jl
+++ b/test/method.jl
@@ -101,6 +101,8 @@ end
             r"^\QExpr[:(x::(Array{\E(.*?)\Q, 1} where \E\1\Q <: Real))]\E$",
             string(f16_alt_sig[:args])
         )
+
+        @test_signature f_symbol_param(x::Val{:foobar}) where T = 2x
     end
 
     @testset "anon functions" begin

--- a/test/method.jl
+++ b/test/method.jl
@@ -55,7 +55,7 @@ end
     end
 
     @testset "Scope Qualification" begin
-        @test_signature qualified_constraint(x::Base.Threads.SpinLock) = 2
+        @test_signature qualified_constraint(x::Base.CoreLogging.LogLevel) = 2
     end
 
     @testset "missing argnames" begin


### PR DESCRIPTION
 - Correctly handle types that are in another name-space
 - Correctly handle `Tuple{}`
 - Correctly handle  Symbols in typeparams (e.g. `Val{:foo}`)
 - <s> I think this also has some other changes, to support other things, but not sure what they are. Hopefully code-cov will tell me if I have added any features i forget about. </s>
 - Some restructuring.

Here are tests that failed before
```julia
julia> @test_signature empty_tuple_constraint(x::Tuple{}) = 2
Test Failed at REPL[48]:5
  Expression: target[:args] == get(candidate, :args, nothing)
   Evaluated: Any[:(x::Tuple{})] == Expr[:(x::Tuple)]
ERROR: There was an error during testing

julia> @test_signature qualified_constraint(x::Base.Threads.SpinLock) = 2
Test Failed at REPL[48]:5
  Expression: target[:args] == get(candidate, :args, nothing)
   Evaluated: Any[:(x::Base.Threads.SpinLock)] == Expr[:(x::var"Base.Threads.SpinLock")]
ERROR: There was an error during testing

julia> @test_signature f_symbol_param(x::Val{:foobar}) where T = 2x
Test Failed at REPL[48]:5
  Expression: target[:args] == get(candidate, :args, nothing)
   Evaluated: Any[:(x::Val{:foobar})] == Expr[:(x::Val{foobar})]
ERROR: There was an error during testing
```