### PR TITLE
add signature from type tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Alternatively see the [MacroTools](https://github.com/MikeInnes/MacroTools.jl) p
 Currently, this package provides the `splitdef`, `signature` and `combinedef` functions which are useful for inspecting and manipulating function definition expressions.
  - `splitdef` works on a function definition expression and returns a `Dict` of its parts.
  - `combinedef` takes a `Dict` from `splitdef` and builds it into an expression.
- - `signature` works on a `Method` returning a similar `Dict` that holds the parts of the expressions that would form its signature.
+ - `signature` works on a `Method`, or the type-tuple `sig` field of a method, returning a similar `Dict` that holds the parts of the expressions that would form its signature.
 
 As well as several helpers that are useful in combination with them.
  - `args_tuple_expr` applies to a `Dict` from `splitdef` or `signature` to generate an expression for a tuple of its arguments.

--- a/src/method.jl
+++ b/src/method.jl
@@ -51,7 +51,7 @@ dictionary that can be passes to `ExprTools.combinedef` to define that function,
 Provided that you assign the `:body` key on the dictionary first.
 
 The quality of the output, in terms of matching names etc is not as high as for the
-`signature(::Method`; but all the key information is present; and the type-typle is for
+`signature(::Method)`, but all the key information is present; and the type-tuple is for
 other purposes generally easier to manipulate.
 
 Examples
@@ -72,8 +72,8 @@ Dict{Symbol, Any} with 3 entries:
 
  - `hygienic_unionalls=false`: if set to `true` this forces name-hygine on the `TypeVar`s in 
    `UnionAll`s, regenerating each with a unique name via `gensym`. This shouldn't actually
-   be requires as they are scoped such that they are not supposed to leak. However, there is
-   a long standing [julia bug](https://github.com/JuliaLang/julia/issues/39876) that means 
+   be required as they are scoped such that they are not supposed to leak. However, there is
+   a long-standing [julia bug](https://github.com/JuliaLang/julia/issues/39876) that means 
    they do leak if they clash with function type-vars.
 """
 function signature(orig_sig::Type{<:Tuple}; hygienic_unionalls=false)
@@ -254,7 +254,7 @@ Note that the similar `Base.rename_unionall`, though `Base.rename_unionall` does
 `gensym` the names just replaces the instances with new instances with identical names.
 """
 function _truly_rename_unionall(@nospecialize(u))
-    isa(u,UnionAll) || return u
+    isa(u, UnionAll) || return u
     body = _truly_rename_unionall(u.body)
     if body === u.body
         body = u

--- a/src/method.jl
+++ b/src/method.jl
@@ -37,8 +37,62 @@ function signature(m::Method)
     def[:params] = type_parameters(m)
     def[:kwargs] = kwargs(m)
 
-    return Dict(k => v for (k, v) in def if v !== nothing)  # filter out nonfields.
+    return filter!(kv->last(kv)!==nothing, def)  # filter out nonfields.
 end
+
+
+"""
+    signature(sig::Type{<:Tuple})
+
+Like `ExprTools.signature(::Method)` but on the underlying signature type-tuple, rather than
+the Method`.
+For `sig` being a tuple-type representing a methods type signature, this generates a
+dictionary that can be passes to `ExprTools.combinedef` to define that function,
+Provided that you assign the `:body` key on the dictionary first.
+
+The quality of the output, in terms of matching names etc is not as high as for the
+`signature(::Method`; but all the key information is present; and the type-typle is for
+other purposes generally easier to manipulate.
+
+Examples
+```julia
+julia> signature(Tuple{typeof(identity), Any})
+Dict{Symbol, Any} with 2 entries:
+  :name => :(op::typeof(identity))
+  :args => Expr[:(x1::Any)]
+
+julia> signature(Tuple{typeof(+), Vector{T}, Vector{T}} where T<:Number)
+Dict{Symbol, Any} with 3 entries:
+  :name        => :(op::typeof(+))
+  :args        => Expr[:(x1::Array{var"##T#5492", 1}), :(x2::Array{var"##T#5492", 1})]
+  :whereparams => Any[:(var"##T#5492" <: Number)]
+```
+
+# keywords
+
+ - `hygienic_unionalls=false`: if set to `true` this forces name-hygine on the `TypeVar`s in 
+   `UnionAll`s, regenerating each with a unique name via `gensym`. This shouldn't actually
+   be requires as they are scoped such that they are not supposed to leak. However, there is
+   a long standing [julia bug](https://github.com/JuliaLang/julia/issues/39876) that means 
+   they do leak if they clash with function type-vars.
+"""
+function signature(orig_sig::Type{<:Tuple}; hygienic_unionalls=false)
+    sig = hygienic_unionalls ? _truly_rename_unionall(orig_sig) : orig_sig
+    def = Dict{Symbol, Any}()
+
+    opT = parameters(sig)[1]
+    def[:name] = :(op::$opT)
+
+    arg_types = name_of_type.(argument_types(sig))
+    arg_names = [Symbol(:x, ii) for ii in eachindex(arg_types)]
+    def[:args] = Expr.(:(::), arg_names, arg_types)
+    def[:whereparams] = where_parameters(sig)
+
+    filter!(kv->last(kv)!==nothing, def)  # filter out nonfields.
+    return def
+end
+
+
 
 function slot_names(m::Method)
     ci = Base.uncompressed_ast(m)
@@ -177,4 +231,37 @@ function kwarg_names(m::Method)
     mt = Base.get_methodtable(m)
     !isdefined(mt, :kwsorter) && return []  # no kwsorter means no keywords for sure.
     return Base.kwarg_decl(m, typeof(mt.kwsorter))
+end
+
+
+
+"""
+    _truly_rename_unionall(@nospecialize(u))
+
+For `u` being a `UnionAll` this replaces every `TypeVar` with  a new one with a `gensym`ed
+names.
+This shouldn't actually be required as they are scoped such that they are not supposed to leak. However, there is
+a long standing [julia bug](https://github.com/JuliaLang/julia/issues/39876) that means 
+they do leak if they clash with function type-vars.
+
+Example:
+```julia
+julia> _truly_rename_unionall(Array{T, N} where {T<:Number, N})
+Array{var"##T#2881", var"##N#2880"} where var"##N#2880" where var"##T#2881"<:Number
+```
+
+Note that the similar `Base.rename_unionall`, though `Base.rename_unionall` does not
+`gensym` the names just replaces the instances with new instances with identical names.
+"""
+function _truly_rename_unionall(@nospecialize(u))
+    isa(u,UnionAll) || return u
+    body = _truly_rename_unionall(u.body)
+    if body === u.body
+        body = u
+    else
+        body = UnionAll(u.var, body)
+    end
+    var = u.var::TypeVar
+    nv = TypeVar(gensym(var.name), var.lb, var.ub)
+    return UnionAll(nv, body{nv})
 end

--- a/test/method.jl
+++ b/test/method.jl
@@ -258,14 +258,14 @@ end
             :whereparams => Any[:(T <: Real)],
         )
 
-        @testset "hygienic_unionalls" begin
+        @testset "extra_hygiene" begin
             no_hygiene = signature(Tuple{typeof(+),T,Array} where T)
             @test no_hygiene == Dict(
                 :name => :(op::$(typeof(+))),
                 :args => Expr[:(x1::T), :(x2::(Array{T, N} where {T, N}))],
                 :whereparams => Any[:T],
             )
-            hygiene = signature(Tuple{typeof(+),T,Array} where T; hygienic_unionalls=true)
+            hygiene = signature(Tuple{typeof(+),T,Array} where T; extra_hygiene=true)
             @test no_hygiene[:name] == hygiene[:name]
             @test length(no_hygiene[:args]) == 2
             @test no_hygiene[:args][2] == hygiene[:args][2]

--- a/test/method.jl
+++ b/test/method.jl
@@ -234,4 +234,43 @@ end
             only_method(OneParamStruct{Float32}, Tuple{Float32, Bool})
         )
     end
+
+    @testset "signature(type_tuple)" begin
+        # our tests here are much less comprehensive than for `signature(::Method)`
+        # but that is OK, as most of the code is shared between the two
+
+        @test signature(Tuple{typeof(+), Float32, Float32}) == Dict(
+            :name => :(op::typeof(+)),
+            :args => Expr[:(x1::Float32), :(x2::Float32)],
+        )
+
+        @test signature(Tuple{typeof(+), Array}) == Dict(
+            :name => :(op::typeof(+)),
+            :args => Expr[:(x1::(Array{T, N} where {T, N}))],
+        )
+
+        @test signature(Tuple{typeof(+), Vector{T}, Matrix{T}} where T<:Real) == Dict(
+            :name => :(op::typeof(+)),
+            :args => Expr[:(x1::Array{T, 1}), :(x2::Array{T, 2})],
+            :whereparams => Any[:(T <: Real)],
+        )
+
+        @testset "hygienic_unionalls" begin
+            no_hygiene = signature(Tuple{typeof(+),T,Array} where T)
+            @test no_hygiene == Dict(
+                :name => :(op::typeof(+)),
+                :args => Expr[:(x1::T), :(x2::(Array{T, N} where {T, N}))],
+                :whereparams => Any[:T],
+            )
+            hygiene = signature(Tuple{typeof(+),T,Array} where T; hygienic_unionalls=true)
+            @test no_hygiene[:name] == hygiene[:name]
+            @test length(no_hygiene[:args]) == 2
+            @test no_hygiene[:args][2] == hygiene[:args][2]
+            
+            @test length(no_hygiene[:whereparams]) == 1
+            @test no_hygiene[:whereparams] != hygiene[:whereparams]
+            # very coarse test to make sure the renamed arg is in the expression it should be
+            @test occursin(string(no_hygiene[:whereparams][1]), string(no_hygiene[:args][1]))
+        end
+    end
 end

--- a/test/method.jl
+++ b/test/method.jl
@@ -269,7 +269,7 @@ end
             @test no_hygiene[:name] == hygiene[:name]
             @test length(no_hygiene[:args]) == 2
             @test no_hygiene[:args][1] != hygiene[:args][1] # different Symbols
-            @test no_hygiene[:arg s][2] == hygiene[:args][2]
+            @test no_hygiene[:args][2] == hygiene[:args][2]
             
             @test length(no_hygiene[:whereparams]) == 1
             @test no_hygiene[:whereparams] != hygiene[:whereparams]  # different Symbols

--- a/test/method.jl
+++ b/test/method.jl
@@ -240,17 +240,20 @@ end
         # but that is OK, as most of the code is shared between the two
 
         @test signature(Tuple{typeof(+), Float32, Float32}) == Dict(
-            :name => :(op::typeof(+)),
+            # Notice the type of the function object is actually interpolated in to the Expr
+            # This is useful because it bypasses julia's pretection for overloading things
+            # which Nabla (and probably others generating overloads) depends upon
+            :name => :(op::$(typeof(+))),
             :args => Expr[:(x1::Float32), :(x2::Float32)],
         )
 
         @test signature(Tuple{typeof(+), Array}) == Dict(
-            :name => :(op::typeof(+)),
+            :name => :(op::$(typeof(+))),
             :args => Expr[:(x1::(Array{T, N} where {T, N}))],
         )
 
         @test signature(Tuple{typeof(+), Vector{T}, Matrix{T}} where T<:Real) == Dict(
-            :name => :(op::typeof(+)),
+            :name => :(op::$(typeof(+))),
             :args => Expr[:(x1::Array{T, 1}), :(x2::Array{T, 2})],
             :whereparams => Any[:(T <: Real)],
         )
@@ -258,7 +261,7 @@ end
         @testset "hygienic_unionalls" begin
             no_hygiene = signature(Tuple{typeof(+),T,Array} where T)
             @test no_hygiene == Dict(
-                :name => :(op::typeof(+)),
+                :name => :(op::$(typeof(+))),
                 :args => Expr[:(x1::T), :(x2::(Array{T, N} where {T, N}))],
                 :whereparams => Any[:T],
             )

--- a/test/method.jl
+++ b/test/method.jl
@@ -268,10 +268,11 @@ end
             hygiene = signature(Tuple{typeof(+),T,Array} where T; extra_hygiene=true)
             @test no_hygiene[:name] == hygiene[:name]
             @test length(no_hygiene[:args]) == 2
-            @test no_hygiene[:args][2] == hygiene[:args][2]
+            @test no_hygiene[:args][1] != hygiene[:args][1] # different Symbols
+            @test no_hygiene[:arg s][2] == hygiene[:args][2]
             
             @test length(no_hygiene[:whereparams]) == 1
-            @test no_hygiene[:whereparams] != hygiene[:whereparams]
+            @test no_hygiene[:whereparams] != hygiene[:whereparams]  # different Symbols
             # very coarse test to make sure the renamed arg is in the expression it should be
             @test occursin(string(no_hygiene[:whereparams][1]), string(no_hygiene[:args][1]))
         end


### PR DESCRIPTION
This is the major thing that is needed for https://github.com/invenia/Nabla.jl/pull/189
and it is extracted from that PR.

`signature(::Method)` seems cool but it is much easier to work with the type tuple from `Method.sig`