### PR TITLE
make parameters part of public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Currently, this package provides the `splitdef`, `signature` and `combinedef` fu
  - `splitdef` works on a function definition expression and returns a `Dict` of its parts.
  - `combinedef` takes a `Dict` from `splitdef` and builds it into an expression.
  - `signature` works on a `Method` returning a similar `Dict` that holds the parts of the expressions that would form its signature.
+ - `parameters` which return the type-parameters of a type, and so is useful for working with the type-tuple that comes out of the `sig` field of a `Method`
 
 
 e.g.
@@ -52,6 +53,9 @@ g (generic function with 1 method)
 
 julia> g_method = first(methods(g))
 g(x::T, y::T) where T in Main
+
+julia> parameters(g_method.sig)
+svec(typeof(g), T, T)
 
 julia> signature(g_method)
 Dict{Symbol,Any} with 3 entries:

--- a/src/ExprTools.jl
+++ b/src/ExprTools.jl
@@ -1,6 +1,6 @@
 module ExprTools
 
-export signature, splitdef, combinedef
+export signature, splitdef, combinedef, parameters
 
 include("function.jl")
 include("method.jl")

--- a/src/type_utils.jl
+++ b/src/type_utils.jl
@@ -7,3 +7,4 @@ e.g. `parameters(Foo{A, B, C}) == [A, B, C]`
 """
 parameters(sig::UnionAll) = parameters(sig.body)
 parameters(sig::DataType) = sig.parameters
+parameters(sig::Union) = Base.uniontypes(sig)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,5 @@ using Test
 @testset "ExprTools.jl" begin
     include("function.jl")
     include("method.jl")
+    include("type_utils.jl")
 end

--- a/test/type_utils.jl
+++ b/test/type_utils.jl
@@ -1,0 +1,62 @@
+@testset "type_utils.jl" begin
+    @testset "parameters" begin
+        # basic case
+        @test collect(parameters(AbstractArray{Float32, 3})) == [Float32, 3]
+        # Type-alias
+        @test collect(parameters(Vector{Float64})) == [Float64, 1]
+
+        # Tuple
+        @test collect(parameters(Tuple{Int8, Bool})) == [Int8, Bool]
+        
+        # Tuple with fixed count Vararg
+        @test collect(parameters(Tuple{Int8, Vararg{Bool, 3}})) == [Int8, Bool, Bool, Bool]
+
+        # Tuple with varadic Vararg
+        a, b = collect(parameters(Tuple{Int8, Vararg{Bool}}))
+        @test a == Int8
+        @test b <: Vararg{Bool}
+
+        # TypeVar
+        tvar1 = parameters(Tuple{T} where T<:Number)[1]
+        @test tvar1 isa TypeVar
+        @test tvar1.name == :T
+        @test tvar1.lb == Union{}
+        @test tvar1.ub == Number
+        
+        # Shared TypeVar
+        tvar2, tvar3 = parameters(Tuple{X,X} where X<:Integer)
+        @test tvar2 === tvar3
+        @test tvar2.name == :X
+        @test tvar2.lb == Union{}
+        @test tvar2.ub == Integer
+        
+        # Shared TypeVar in different parameter 
+        tvar4, part = parameters(Tuple{Y,Tuple{Y}} where Integer <: Y <: Real)
+        @test part <: Tuple
+        tvar5 = parameters(part)[1]
+        @test tvar4 === tvar5
+        @test tvar4.name == :Y
+        @test tvar4.lb == Integer
+        @test tvar4.ub == Real
+
+        # Union
+        @test Set(parameters(Union{Int8, Bool})) == Set([Int8, Bool])
+        @test Set(parameters(Union{Int8, Bool, Set})) == Set([Int8, Bool, Set])
+        
+        # Partially collapsing Union
+        @test Set(parameters(Union{Int8, Real, Set})) == Set([Real, Set])
+
+        # Unions with type-vars
+        umem1, umem2 = parameters(Union{Tuple{Z}, Set{Z}} where Z)
+        utvar1 = parameters(umem1)[1]
+        utvar2 = parameters(umem2)[1]
+        @test utvar1 == utvar2
+        @test utvar1 isa TypeVar
+        @test utvar1.name == :Z
+        @test utvar1.lb == Union{}
+        @test utvar1.ub == Any
+
+        # Non-parametric type
+        @test isempty(parameters(Bool))
+    end     
+end


### PR DESCRIPTION
This is a really useful method for manipulating type-tuples.
It was being used in https://github.com/invenia/Nabla.jl/pull/189
(thought it has long been an internal part of ExprTools)

It is a surprisingly fiddly little function.
Often people just use `T.parameters` but that breaks for `Union`s and `UnionAll`s.

This PR exports it.
When doing so I added a full test suite.
In doing so i found out it didn't work for `Union`s, so I fixed that also.