### PR TITLE
Allow callable structs in argument_names

### DIFF
--- a/src/method.jl
+++ b/src/method.jl
@@ -100,7 +100,6 @@ end
 function argument_names(m::Method)
     slot_syms = slot_names(m)
     # nargs includes 1 for `#self#` or the function object name;
-    # TODO: could support option to return function object argument name/type
     arg_names = slot_syms[2:m.nargs]
     return arg_names
 end

--- a/src/method.jl
+++ b/src/method.jl
@@ -92,8 +92,6 @@ function signature(orig_sig::Type{<:Tuple}; extra_hygiene=false)
     return def
 end
 
-
-
 function slot_names(m::Method)
     ci = Base.uncompressed_ast(m)
     return ci.slotnames
@@ -101,8 +99,9 @@ end
 
 function argument_names(m::Method)
     slot_syms = slot_names(m)
-    @assert slot_syms[1] === Symbol("#self#")
-    arg_names = slot_syms[2:m.nargs]  # nargs includes 1 for `#self#`
+    # nargs includes 1 for `#self#` or the function object name;
+    # TODO: could support option to return function object argument name/type
+    arg_names = slot_syms[2:m.nargs]
     return arg_names
 end
 

--- a/test/method.jl
+++ b/test/method.jl
@@ -118,10 +118,10 @@ struct TestCallableStruct end
 
     @testset "callable structs" begin
         ms = collect(methods(TestCallableStruct()))
-        sig1 = signature(filter(m -> m.nargs == 2, ms) |> first)
+        sig1 = signature(first(filter(m -> m.nargs == 2, ms)))
         @test sig1[:name] == :TestCallableStruct
         @test sig1[:args] == [:x]
-        sig2 = signature(filter(m -> m.nargs == 3, ms) |> first)
+        sig2 = signature(first(filter(m -> m.nargs == 3, ms)))
         @test sig2[:name] == :TestCallableStruct
         @test sig2[:args] == Expr[:(x::T),:(y::R)]
     end

--- a/test/method.jl
+++ b/test/method.jl
@@ -118,10 +118,10 @@ struct TestCallableStruct end
 
     @testset "callable structs" begin
         ms = collect(methods(TestCallableStruct()))
-        sig1 = signature(ms[1])
+        sig1 = signature(filter(m -> m.nargs == 2, ms) |> first)
         @test sig1[:name] == :TestCallableStruct
         @test sig1[:args] == [:x]
-        sig2 = signature(ms[2])
+        sig2 = signature(filter(m -> m.nargs == 3, ms) |> first)
         @test sig2[:name] == :TestCallableStruct
         @test sig2[:args] == Expr[:(x::T),:(y::R)]
     end

--- a/test/method.jl
+++ b/test/method.jl
@@ -42,6 +42,10 @@ function only_method(f, typ=Tuple{Vararg{Any}})
     return first(ms)
 end
 
+struct TestCallableStruct end
+(self::TestCallableStruct)(x) = 2x
+(self::TestCallableStruct)(x::T,y::R) where {T,R} = 2x + y
+
 @testset "method.jl: signature" begin
     @testset "Basics" begin
         @test_signature basic1(x) = 2x
@@ -110,6 +114,16 @@ end
         @test_signature (x) -> 2x
 
         @test_signature ((::T) where T) -> 0   # Anonymous parameter
+    end
+
+    @testset "callable structs" begin
+        ms = collect(methods(TestCallableStruct()))
+        sig1 = signature(ms[1])
+        @test sig1[:name] == :TestCallableStruct
+        @test sig1[:args] == [:x]
+        sig2 = signature(ms[2])
+        @test sig2[:name] == :TestCallableStruct
+        @test sig2[:args] == Expr[:(x::T),:(y::R)]
     end
 
     @testset "vararg" begin


### PR DESCRIPTION
Fixes #16

In the future, we could add full support for callable structs by allowing the user to specify whether or not to include the first argument name/type in the output of `signature`. I'm not sure that we want to do it automatically because 1) this would introduce inconsistency into the behavior and 2) excluding the function object name/type is probably the most common use case. In fact, one would (I think) always need to have an instance of the struct available in order to obtain the corresponding method anyway, so it's probably redundant.