### PR TITLE
Add test for varadic tuples in signature

### DIFF
--- a/test/method.jl
+++ b/test/method.jl
@@ -58,6 +58,10 @@ struct TestCallableStruct end
         @test_signature empty_tuple_constraint(x::Tuple{}) = 2
     end
 
+    @testset "varadic Tuple" begin
+        @test_signature vt1(::Tuple{Vararg{Int64, N}}) where N = 2
+    end
+
     @testset "Scope Qualification" begin
         @test_signature qualified_constraint(x::Base.CoreLogging.LogLevel) = 2
     end


### PR DESCRIPTION
I thought this might be broken, but it seems it wasn't.
During the investigation I wrote this test.
It seems worth keeping around