### PR TITLE
fix docstring of args_tuple_expr

### DIFF
--- a/src/def_tools.jl
+++ b/src/def_tools.jl
@@ -8,7 +8,7 @@
     args_tuple_expr(arg_exprs)
 
 For `arg_exprs` being a list of positional argument expressions from a signature, of a form
-such as `[:(x::Int), :(y::Float64), :(z::Vararg)]`, or being a whole signature_def `Dict`
+such as `[:(x::Int), :(y::Float64), :(z::Vararg)]`, or being a whole `signature_def` `Dict`
 containing a `signature_def[:args]` value of that form.
 
 This returns a tuple expresion containing all of the args by name. It correctly handles


### PR DESCRIPTION
A non-quoted underscore was being treated as a Markdown "underline" marker:
![args_tuple_expr](https://user-images.githubusercontent.com/8462914/146677118-d1966f47-5f33-4a51-b455-dc74df196ee8.png)
