### PR TITLE
splitdef: handle invalid `Expr(:function, :(f(x)))`

### DIFF
--- a/src/function.jl
+++ b/src/function.jl
@@ -39,7 +39,8 @@ function splitdef(ex::Expr; throw::Bool=true)
 
     def[:head] = ex.head
 
-    if ex.head === :function && length(ex.args) == 1  # empty function definition
+    if ex.head === :function && length(ex.args) == 1 && ex.args[1] isa Symbol
+        # empty function definition
         def[:name] = ex.args[1]
         return def
     elseif length(ex.args) == 2  # Expect signature and body

--- a/test/function.jl
+++ b/test/function.jl
@@ -844,6 +844,7 @@ function_form(short::Bool) = string(short ? "short" : "long", "-form")
         # Too few expression arguments
         @test_splitdef_invalid Expr(:function)
         @test_splitdef_invalid Expr(:(=), :f)
+        @test_splitdef_invalid Expr(:function, :(f(x)))
 
         # Too many expression arguments
         @test_splitdef_invalid Expr(:function, :f, :x, :y)


### PR DESCRIPTION
This would previously result in `:name => :(f(x))`.