### PR TITLE
Fix on Julia 1.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExprTools"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 authors = ["Invenia Technical Computing"]
-version = "0.1.7"
+version = "0.1.8"
 
 [compat]
 julia = "1"

--- a/src/method.jl
+++ b/src/method.jl
@@ -181,7 +181,7 @@ end
 # Vararg was changed not to be a type anymore in Julia 1.7
 if isdefined(Core, :TypeofVararg)
     function name_of_type(x::Core.TypeofVararg)
-        of_T = name_of_type(x.T)
+        of_T = isdefined(x, :T) ? name_of_type(x.T) : :Any
         if isdefined(x, :N)
             :(Vararg{$of_T,$(name_of_type(x.N))})
         else

--- a/src/method.jl
+++ b/src/method.jl
@@ -141,7 +141,7 @@ function name_of_type(x::Core.TypeName)
 end
 
 name_of_type(x::Symbol) = QuoteNode(x)  # Literal type-param e.g. `Val{:foo}`
-function name_of_type(x::T) where T  # Literal type-param e.g. `Val{1}`
+function name_of_type(x::T) where {T}  # Literal type-param e.g. `Val{1}`
     # If this error is thrown, there is an issue with our implementation
     isbits(x) || throw(DomainError((x, T), "not a valid type-param"))
     return x
@@ -183,13 +183,12 @@ if isdefined(Core, :TypeofVararg)
     function name_of_type(x::Core.TypeofVararg)
         of_T = name_of_type(x.T)
         if isdefined(x, :N)
-            :(Vararg{$of_T, $(name_of_type(x.N))})
+            :(Vararg{$of_T,$(name_of_type(x.N))})
         else
             :(Vararg{$of_T})
         end
     end
 end
-
 
 function arguments(m::Method, sig=m.sig)
     arg_names = argument_names(m)

--- a/test/method.jl
+++ b/test/method.jl
@@ -59,8 +59,8 @@ struct TestCallableStruct end
     end
 
     @testset "varadic Tuple" begin
-        @test_signature vt1(::Tuple{Vararg{Int64, N}}) where N = 2
-        VERSION >= v"1.7" && @test_signature vt2(::Tuple{Vararg{Int64}})= 2
+        @test_signature vt1(::Tuple{Vararg{Int64,N}}) where {N} = 2
+        VERSION >= v"1.7" && @test_signature vt2(::Tuple{Vararg{Int64}}) = 2
     end
 
     @testset "Scope Qualification" begin
@@ -139,29 +139,23 @@ struct TestCallableStruct end
             f17_alt(xs...) = 2
             test_matches(
                 signature(only_method(f17_alt)),
-                Dict(
-                    :name => :f17_alt,
-                    :args => [:(xs::Vararg{Any})]
-                )
+                Dict(:name => :f17_alt, :args => [:(xs::Vararg{Any})]),
             )
 
             @test_signature f18(xs::Vararg{Int64}) = 2
             @test_signature f19(x, xs::Vararg{Any}) = 2x
         else
-            @test_signature f17(xs::Vararg{Any, N} where N) = 2
-                    # `f17_alt(xs...) = 2` lowers to the same method as `f18`
+            @test_signature f17(xs::Vararg{Any,N} where {N}) = 2
+            # `f17_alt(xs...) = 2` lowers to the same method as `f18`
             # but has a different AST according to `splitdef` so we can't us @test_signature
             f17_alt(xs...) = 2
             test_matches(
                 signature(only_method(f17_alt)),
-                Dict(
-                    :name => :f17_alt,
-                    :args => [:(xs::(Vararg{Any, N} where N))]
-                )
+                Dict(:name => :f17_alt, :args => [:(xs::(Vararg{Any,N} where {N}))]),
             )
 
-            @test_signature f18(xs::Vararg{Int64, N} where N) = 2
-            @test_signature f19(x, xs::Vararg{Any, N} where N) = 2x
+            @test_signature f18(xs::Vararg{Int64,N} where {N}) = 2
+            @test_signature f19(x, xs::Vararg{Any,N} where {N}) = 2x
         end
     end
 

--- a/test/method.jl
+++ b/test/method.jl
@@ -323,10 +323,11 @@ struct TestCallableStruct end
             @test length(no_hygiene[:whereparams]) == 1
             @test no_hygiene[:whereparams] != hygiene[:whereparams]  # different Symbols
             # very coarse test to make sure the renamed arg is in the expression it should be
-            @test occursin(string(no_hygiene[:whereparams][1]), string(no_hygiene[:args][1]))
+            @test occursin(
+                string(no_hygiene[:whereparams][1]), string(no_hygiene[:args][1])
+            )
         end
     end
-
 
     @testset "internals" begin
         @testset "name_of_type" begin

--- a/test/method.jl
+++ b/test/method.jl
@@ -134,7 +134,7 @@ struct TestCallableStruct end
     @testset "vararg" begin
         if VERSION >= v"1.7"
             @test_signature f17(xs::Vararg{Any}) = 2
-            # `f17_alt(xs...) = 2` lowers to the same method as `f18`
+            # `f17_alt(xs...) = 2` lowers to the same method as `f17`
             # but has a different AST according to `splitdef` so we can't us @test_signature
             f17_alt(xs...) = 2
             test_matches(
@@ -145,17 +145,17 @@ struct TestCallableStruct end
             @test_signature f18(xs::Vararg{Int64}) = 2
             @test_signature f19(x, xs::Vararg{Any}) = 2x
         else
-            @test_signature f17(xs::Vararg{Any,N} where {N}) = 2
-            # `f17_alt(xs...) = 2` lowers to the same method as `f18`
+            @test_signature f17b(xs::Vararg{Any,N} where {N}) = 2
+            # `f17b_alt(xs...) = 2` lowers to the same method as `f17b`
             # but has a different AST according to `splitdef` so we can't us @test_signature
-            f17_alt(xs...) = 2
+            f17b_alt(xs...) = 2
             test_matches(
-                signature(only_method(f17_alt)),
-                Dict(:name => :f17_alt, :args => [:(xs::(Vararg{Any,N} where {N}))]),
+                signature(only_method(f17b_alt)),
+                Dict(:name => :f17b_alt, :args => [:(xs::(Vararg{Any,N} where {N}))]),
             )
 
-            @test_signature f18(xs::Vararg{Int64,N} where {N}) = 2
-            @test_signature f19(x, xs::Vararg{Any,N} where {N}) = 2x
+            @test_signature f18b(xs::Vararg{Int64,N} where {N}) = 2
+            @test_signature f19b(x, xs::Vararg{Any,N} where {N}) = 2x
         end
     end
 

--- a/test/method.jl
+++ b/test/method.jl
@@ -60,6 +60,7 @@ struct TestCallableStruct end
 
     @testset "varadic Tuple" begin
         @test_signature vt1(::Tuple{Vararg{Int64, N}}) where N = 2
+        VERSION >= v"1.7" && @test_signature vt2(::Tuple{Vararg{Int64}})= 2
     end
 
     @testset "Scope Qualification" begin
@@ -131,21 +132,37 @@ struct TestCallableStruct end
     end
 
     @testset "vararg" begin
-        @test_signature f17(xs::Vararg{Any, N} where N) = 2
-
-        # `f17_alt(xs...) = 2` lowers to the same method as `f18`
-        # but has a different AST according to `splitdef` so we can't us @test_signature
-        f17_alt(xs...) = 2
-        test_matches(
-            signature(only_method(f17_alt)),
-            Dict(
-                :name => :f17_alt,
-                :args => [:(xs::(Vararg{Any, N} where N))]
+        if VERSION >= v"1.7"
+            @test_signature f17(xs::Vararg{Any}) = 2
+            # `f17_alt(xs...) = 2` lowers to the same method as `f18`
+            # but has a different AST according to `splitdef` so we can't us @test_signature
+            f17_alt(xs...) = 2
+            test_matches(
+                signature(only_method(f17_alt)),
+                Dict(
+                    :name => :f17_alt,
+                    :args => [:(xs::Vararg{Any})]
+                )
             )
-        )
 
-        @test_signature f18(xs::Vararg{Int64, N} where N) = 2
-        @test_signature f19(x, xs::Vararg{Any, N} where N) = 2x
+            @test_signature f18(xs::Vararg{Int64}) = 2
+            @test_signature f19(x, xs::Vararg{Any}) = 2x
+        else
+            @test_signature f17(xs::Vararg{Any, N} where N) = 2
+                    # `f17_alt(xs...) = 2` lowers to the same method as `f18`
+            # but has a different AST according to `splitdef` so we can't us @test_signature
+            f17_alt(xs...) = 2
+            test_matches(
+                signature(only_method(f17_alt)),
+                Dict(
+                    :name => :f17_alt,
+                    :args => [:(xs::(Vararg{Any, N} where N))]
+                )
+            )
+
+            @test_signature f18(xs::Vararg{Int64, N} where N) = 2
+            @test_signature f19(x, xs::Vararg{Any, N} where N) = 2x
+        end
     end
 
     @testset "kwargs" begin

--- a/test/method.jl
+++ b/test/method.jl
@@ -326,4 +326,13 @@ struct TestCallableStruct end
             @test occursin(string(no_hygiene[:whereparams][1]), string(no_hygiene[:args][1]))
         end
     end
+
+
+    @testset "internals" begin
+        @testset "name_of_type" begin
+            # This isn't part of the public API, and isn't currently hit by anything that is
+            # but it really seems like it should work.
+            VERSION >= v"1.7" && @test ExprTools.name_of_type(Vararg) == :(Vararg{Any})
+        end
+    end
 end

--- a/test/type_utils.jl
+++ b/test/type_utils.jl
@@ -1,15 +1,15 @@
 @testset "type_utils.jl" begin
     @testset "parameters" begin
         # basic case
-        @test collect(parameters(AbstractArray{Float32, 3})) == [Float32, 3]
+        @test collect(parameters(AbstractArray{Float32,3})) == [Float32, 3]
         # Type-alias
         @test collect(parameters(Vector{Float64})) == [Float64, 1]
 
         # Tuple
-        @test collect(parameters(Tuple{Int8, Bool})) == [Int8, Bool]
+        @test collect(parameters(Tuple{Int8,Bool})) == [Int8, Bool]
         
         # Tuple with fixed count Vararg
-        @test collect(parameters(Tuple{Int8, Vararg{Bool, 3}})) == [Int8, Bool, Bool, Bool]
+        @test collect(parameters(Tuple{Int8,Vararg{Bool,3}})) == [Int8, Bool, Bool, Bool]
 
         # Tuple with varadic Vararg
         a, b = collect(parameters(Tuple{Int8,Vararg{Bool}}))
@@ -40,14 +40,14 @@
         @test tvar4.ub == Real
 
         # Union
-        @test Set(parameters(Union{Int8, Bool})) == Set([Int8, Bool])
-        @test Set(parameters(Union{Int8, Bool, Set})) == Set([Int8, Bool, Set])
+        @test Set(parameters(Union{Int8,Bool})) == Set([Int8, Bool])
+        @test Set(parameters(Union{Int8,Bool,Set})) == Set([Int8, Bool, Set])
         
         # Partially collapsing Union
-        @test Set(parameters(Union{Int8, Real, Set})) == Set([Real, Set])
+        @test Set(parameters(Union{Int8,Real,Set})) == Set([Real, Set])
 
         # Unions with type-vars
-        umem1, umem2 = parameters(Union{Tuple{Z}, Set{Z}} where Z)
+        umem1, umem2 = parameters(Union{Tuple{Z},Set{Z}} where Z)
         utvar1 = parameters(umem1)[1]
         utvar2 = parameters(umem2)[1]
         @test utvar1 == utvar2

--- a/test/type_utils.jl
+++ b/test/type_utils.jl
@@ -7,7 +7,6 @@
 
         # Tuple
         @test collect(parameters(Tuple{Int8,Bool})) == [Int8, Bool]
-        
         # Tuple with fixed count Vararg
         @test collect(parameters(Tuple{Int8,Vararg{Bool,3}})) == [Int8, Bool, Bool, Bool]
 
@@ -42,12 +41,11 @@
         # Union
         @test Set(parameters(Union{Int8,Bool})) == Set([Int8, Bool])
         @test Set(parameters(Union{Int8,Bool,Set})) == Set([Int8, Bool, Set])
-        
         # Partially collapsing Union
         @test Set(parameters(Union{Int8,Real,Set})) == Set([Real, Set])
 
         # Unions with type-vars
-        umem1, umem2 = parameters(Union{Tuple{Z},Set{Z}} where Z)
+        umem1, umem2 = parameters(Union{Tuple{Z},Set{Z}} where {Z})
         utvar1 = parameters(umem1)[1]
         utvar2 = parameters(umem2)[1]
         @test utvar1 == utvar2

--- a/test/type_utils.jl
+++ b/test/type_utils.jl
@@ -12,12 +12,12 @@
         @test collect(parameters(Tuple{Int8, Vararg{Bool, 3}})) == [Int8, Bool, Bool, Bool]
 
         # Tuple with varadic Vararg
-        a, b = collect(parameters(Tuple{Int8, Vararg{Bool}}))
+        a, b = collect(parameters(Tuple{Int8,Vararg{Bool}}))
         @test a == Int8
         @test b == Vararg{Bool}
 
         # TypeVar
-        tvar1 = parameters(Tuple{T} where T<:Number)[1]
+        tvar1 = parameters(Tuple{T} where {T<:Number})[1]
         @test tvar1 isa TypeVar
         @test tvar1.name == :T
         @test tvar1.lb == Union{}

--- a/test/type_utils.jl
+++ b/test/type_utils.jl
@@ -14,7 +14,7 @@
         # Tuple with varadic Vararg
         a, b = collect(parameters(Tuple{Int8, Vararg{Bool}}))
         @test a == Int8
-        @test b <: Vararg{Bool}
+        @test b == Vararg{Bool}
 
         # TypeVar
         tvar1 = parameters(Tuple{T} where T<:Number)[1]


### PR DESCRIPTION
Closes #32 and #28 

`Vararg` on 1.7 is not a type any more.
So it gets its own path through the code.
This does mean we actually generate nicer code with that.
(because it was easier to generate nicer code than workout how to generate code identical to what we had before).
But that also means we needed to put some branches in the tests where they do produce nicer code

This PR blocks fixing Nabla to work on Julia 1.7.
(though old versions of Nabla that are PreChainRules are not blocked by this. Including the version in production)