### PR TITLE
Update CI setup, set up Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,49 +15,48 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.6"  # LTS
+          - "1.0"  # oldest supported version
+          - "1.6"  # previous LTS release
+          - "lts"
           - "1"    # Latest Release
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         arch:
-          - x64
-          - x86
+          - default
         exclude:
-          # Test 32-bit only on Linux
+          # macOS default arch is ARM these days which requires Julia >= 1.8
           - os: macOS-latest
+            version: "1.0"
+          - os: macOS-latest
+            version: "1.6"
+        include:
+          # Test 32-bit only on Linux
+          - os: ubuntu-latest
             arch: x86
-          - os: windows-latest
+            version: "lts"
+          - os: ubuntu-latest
             arch: x86
+            version: "1"
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v2
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-${{ matrix.arch }}-test-
-            ${{ runner.os }}-${{ matrix.arch }}-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   slack:
     name: Notify Slack Failure
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: always() && github.event_name == 'schedule'
     steps:
       - uses: technote-space/workflow-conclusion-action@v2
@@ -74,12 +73,12 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: '1'
+          version: 'lts'
       - run: |
-          julia --project=docs -e '
+          julia --project=docs --color -e '
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   CompatHelper:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -8,22 +8,15 @@ jobs:
     name: Julia Nightly - Ubuntu - x64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: nightly
           arch: x64
-      - uses: actions/cache@v2
-        env:
-          cache-name: julianightly-cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ env.cache-name }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,13 +1,18 @@
 name: TagBot
+
 on:
   issue_comment:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:

--- a/.github/workflows/blue_style_formatter.yml
+++ b/.github/workflows/blue_style_formatter.yml
@@ -5,10 +5,10 @@ on:
 
 jobs:
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: 1
       - run: |

--- a/test/type_utils.jl
+++ b/test/type_utils.jl
@@ -58,7 +58,9 @@
         @test isempty(parameters(Bool))
 
         # type-vars in signatures
-        s = only(parameters(TypeVar(:T)))
+        p = parameters(TypeVar(:T))
+        @test length(p) == 1
+        s = first(p)
         @test s.name == :T
         @test s.lb == Union{}
         @test s.ub == Any
@@ -66,7 +68,9 @@
         # https://github.com/JuliaTesting/ExprTools.jl/issues/39
         @testset "#39" begin
             s = signature(Tuple{Type{T},T} where {T<:Number})
-            @test only(s[:whereparams]).args[1] == :T
+            w = s[:whereparams]
+            @test length(w) == 1
+            @test first(w).args[1] == :T
         end
     end
 end


### PR DESCRIPTION
This also restores code coverage reporting and adds tests against the actual LTS as well as against Julia 1.0 (which is the oldest Julia version this package claims to support; this required one tweak to the tests as `only` is not available in Julia 1.0). And it avoids running tests on macOS in rosetta (the x86 emulator).

The tests fail in Julia 1.12, though. But fixing that is out of scope for this PR, IMHO. I just wanted to make sure CI actually works.