### PR TITLE
remove slack notification from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,22 +53,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  slack:
-    name: Notify Slack Failure
-    needs: test
-    runs-on: ubuntu-slim
-    if: always() && github.event_name == 'schedule'
-    steps:
-      - uses: technote-space/workflow-conclusion-action@v2
-      - uses: voxmedia/github-action-slack-notify-build@v1
-        if: env.WORKFLOW_CONCLUSION == 'failure'
-        with:
-          channel: nightly-dev
-          status: FAILED
-          color: danger
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.DEV_SLACK_BOT_TOKEN }}
-
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
The company which was maintaining this and so had slack alerts set up no longer exists.